### PR TITLE
feat: 通知に連続服薬日数を追加 (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,7 @@ Uses JWT-based authentication middleware for protected routes. User ID is extrac
 - **MedicationLog**: Tracks medication intake with bleeding status
 - **NotificationSetting**: Manages user notification preferences per platform
 - **User**: User authentication and identification
+
+## Development Rules
+
+- **Language**: Always respond in Japanese when working in this repository

--- a/internal/repository/medication.go
+++ b/internal/repository/medication.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"okusuri-backend/internal/model"
 	"okusuri-backend/pkg/config"
+	"time"
 )
 
 type MedicationRepository struct{}
@@ -73,4 +74,51 @@ func (r *MedicationRepository) UpdateLog(userID string, logID uint, hasBleeding 
 	}
 
 	return nil
+}
+
+// GetConsecutiveDays はユーザーの連続服薬日数を計算する
+func (r *MedicationRepository) GetConsecutiveDays(userID string) (int, error) {
+	db := config.DB
+	
+	// ユーザーの服薬ログを日付降順で取得
+	var logs []model.MedicationLog
+	if err := db.Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Find(&logs).Error; err != nil {
+		return 0, err
+	}
+	
+	if len(logs) == 0 {
+		return 0, nil
+	}
+	
+	// 連続日数をカウント
+	consecutiveDays := 1
+	today := time.Now().Truncate(24 * time.Hour)
+	
+	// 最新の記録が今日かどうかチェック
+	latestLog := logs[0]
+	latestDate := latestLog.CreatedAt.Truncate(24 * time.Hour)
+	
+	// 最新の記録が今日でない場合は連続日数は0
+	if !latestDate.Equal(today) {
+		return 0, nil
+	}
+	
+	// 前日から遡って連続日数をカウント
+	expectedDate := today.AddDate(0, 0, -1)
+	
+	for i := 1; i < len(logs); i++ {
+		logDate := logs[i].CreatedAt.Truncate(24 * time.Hour)
+		
+		if logDate.Equal(expectedDate) {
+			consecutiveDays++
+			expectedDate = expectedDate.AddDate(0, 0, -1)
+		} else {
+			// 連続していない場合は終了
+			break
+		}
+	}
+	
+	return consecutiveDays, nil
 }

--- a/internal/repository/medication.go
+++ b/internal/repository/medication.go
@@ -79,7 +79,7 @@ func (r *MedicationRepository) UpdateLog(userID string, logID uint, hasBleeding 
 // GetConsecutiveDays はユーザーの連続服薬日数を計算する
 func (r *MedicationRepository) GetConsecutiveDays(userID string) (int, error) {
 	db := config.DB
-	
+
 	// ユーザーの服薬ログを日付降順で取得
 	var logs []model.MedicationLog
 	if err := db.Where("user_id = ?", userID).
@@ -87,30 +87,30 @@ func (r *MedicationRepository) GetConsecutiveDays(userID string) (int, error) {
 		Find(&logs).Error; err != nil {
 		return 0, err
 	}
-	
+
 	if len(logs) == 0 {
 		return 0, nil
 	}
-	
+
 	// 連続日数をカウント
 	consecutiveDays := 1
 	today := time.Now().Truncate(24 * time.Hour)
-	
+
 	// 最新の記録が今日かどうかチェック
 	latestLog := logs[0]
 	latestDate := latestLog.CreatedAt.Truncate(24 * time.Hour)
-	
+
 	// 最新の記録が今日でない場合は連続日数は0
 	if !latestDate.Equal(today) {
 		return 0, nil
 	}
-	
+
 	// 前日から遡って連続日数をカウント
 	expectedDate := today.AddDate(0, 0, -1)
-	
+
 	for i := 1; i < len(logs); i++ {
 		logDate := logs[i].CreatedAt.Truncate(24 * time.Hour)
-		
+
 		if logDate.Equal(expectedDate) {
 			consecutiveDays++
 			expectedDate = expectedDate.AddDate(0, 0, -1)
@@ -119,6 +119,6 @@ func (r *MedicationRepository) GetConsecutiveDays(userID string) (int, error) {
 			break
 		}
 	}
-	
+
 	return consecutiveDays, nil
 }

--- a/internal/routes.go
+++ b/internal/routes.go
@@ -24,6 +24,7 @@ func SetupRoutes() *gin.Engine {
 		notificationRepo,
 		userRepo,
 		notificationService,
+		medicationRepo,
 	)
 
 	// Ginのルーターを作成

--- a/internal/service/notification.go
+++ b/internal/service/notification.go
@@ -121,10 +121,10 @@ func (s *NotificationService) SendNotificationWithDays(user model.User, setting 
 		Title: "お薬通知",
 		Body:  message,
 		Data: map[string]string{
-			"messageId":        fmt.Sprintf("medication-%d", time.Now().UnixNano()),
-			"timestamp":        fmt.Sprintf("%d", time.Now().Unix()),
-			"userId":           user.ID,
-			"consecutiveDays":  fmt.Sprintf("%d", consecutiveDays),
+			"messageId":       fmt.Sprintf("medication-%d", time.Now().UnixNano()),
+			"timestamp":       fmt.Sprintf("%d", time.Now().Unix()),
+			"userId":          user.ID,
+			"consecutiveDays": fmt.Sprintf("%d", consecutiveDays),
 		},
 	}
 

--- a/internal/service/notification.go
+++ b/internal/service/notification.go
@@ -75,8 +75,8 @@ func (s *NotificationService) markAsSent(subKey string) {
 	}
 }
 
-// SendNotification は通知を送信する
-func (s *NotificationService) SendNotification(user model.User, setting model.NotificationSetting, message string) error {
+// SendNotificationWithDays は連続服薬日数を含めて通知を送信する
+func (s *NotificationService) SendNotificationWithDays(user model.User, setting model.NotificationSetting, message string, consecutiveDays int) error {
 	// subscriptionが空の場合
 	if setting.Subscription == "" {
 		fmt.Printf(">> 通知サービス: ユーザーID: %s のサブスクリプションが空です\n", user.ID)
@@ -116,14 +116,15 @@ func (s *NotificationService) SendNotification(user model.User, setting model.No
 		return fmt.Errorf("VAPID鍵が設定されていません")
 	}
 
-	// 通知内容の作成
+	// 通知内容の作成（連続服薬日数を含める）
 	notificationData := NotificationData{
 		Title: "お薬通知",
 		Body:  message,
 		Data: map[string]string{
-			"messageId": fmt.Sprintf("medication-%d", time.Now().UnixNano()),
-			"timestamp": fmt.Sprintf("%d", time.Now().Unix()),
-			"userId":    user.ID,
+			"messageId":        fmt.Sprintf("medication-%d", time.Now().UnixNano()),
+			"timestamp":        fmt.Sprintf("%d", time.Now().Unix()),
+			"userId":           user.ID,
+			"consecutiveDays":  fmt.Sprintf("%d", consecutiveDays),
 		},
 	}
 
@@ -164,4 +165,9 @@ func (s *NotificationService) SendNotification(user model.User, setting model.No
 	fmt.Printf(">> 通知サービス: ユーザーID %s の処理完了\n", user.ID)
 
 	return nil
+}
+
+// SendNotification は通知を送信する（後方互換性のため）
+func (s *NotificationService) SendNotification(user model.User, setting model.NotificationSetting, message string) error {
+	return s.SendNotificationWithDays(user, setting, message, 0)
 }


### PR DESCRIPTION
## Summary
- Issue #33の対応として、通知に連続服薬日数を表示する機能を実装
- MedicationRepositoryに連続服薬日数を計算する機能を追加
- 通知メッセージに「連続X日目」を表示し、連続していない場合は通常メッセージを表示

## 実装内容
- `MedicationRepository.GetConsecutiveDays()`: ユーザーの連続服薬日数を計算
- `NotificationService.SendNotificationWithDays()`: 連続服薬日数を含む通知送信
- 通知データに`consecutiveDays`フィールドを追加
- メッセージフォーマットを「お薬の時間です。忘れずに服用してください。（連続X日目）」に更新

## Test plan
- [ ] ビルドが正常に完了することを確認
- [ ] 連続服薬記録があるユーザーに通知を送信し、連続日数が表示されることを確認
- [ ] 連続していないユーザーに通知を送信し、通常メッセージが表示されることを確認
- [ ] 服薬記録がないユーザーに通知を送信し、エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)