### PR TITLE
feat: ステータスに応じた通知メッセージを実装 (#31)

### DIFF
--- a/internal/routes.go
+++ b/internal/routes.go
@@ -17,6 +17,7 @@ func SetupRoutes() *gin.Engine {
 
 	// サービスの初期化
 	notificationService := service.NewNotificationService()
+	medicationService := service.NewMedicationService(medicationRepo)
 
 	// ハンドラーの初期化
 	medicationHandler := handler.NewMedicationHandler(medicationRepo)
@@ -25,6 +26,7 @@ func SetupRoutes() *gin.Engine {
 		userRepo,
 		notificationService,
 		medicationRepo,
+		medicationService,
 	)
 
 	// Ginのルーターを作成


### PR DESCRIPTION
## Summary
- Issue #31の対応として、ユーザーの薬のステータスに応じて通知メッセージを変更する機能を実装
- 休薬期間中と通常の服薬期間で異なるメッセージを送信

## 実装内容
- `NotificationHandler`に`MedicationService`を追加
- `generateStatusBasedMessage()`関数でステータスに応じたメッセージを生成
- 休薬期間中: 「現在休薬期間中です。あとX日で服薬を再開してください。」
- 休薬期間終了時: 「休薬期間が終了しました。本日から服薬を再開してください。」
- 通常期間: 「お薬の時間です。忘れずに服用してください。（連続X日目）」
- エラー時のフォールバック処理を追加

## メッセージパターン
1. **休薬期間中（残り日数あり）**: 現在休薬期間中です。あと2日で服薬を再開してください。
2. **休薬期間終了時**: 休薬期間が終了しました。本日から服薬を再開してください。  
3. **通常期間（連続服薬中）**: お薬の時間です。忘れずに服用してください。（連続5日目）
4. **通常期間（初回）**: お薬の時間です。忘れずに服用してください。

## Test plan
- [ ] ビルドが正常に完了することを確認
- [ ] 休薬期間中のユーザーに通知を送信し、適切なメッセージが表示されることを確認
- [ ] 通常期間中のユーザーに通知を送信し、連続日数が表示されることを確認
- [ ] ステータス取得エラー時にフォールバックメッセージが送信されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)